### PR TITLE
Drop support for Node 8.x

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
 
     steps:
       # Setup


### PR DESCRIPTION
This is going to be an Electron app, so ultimately it will be bundled with whatever version of Node it was built with, thus we don't need to worry about backwards-compatibility