### PR TITLE
Replace hasOwnProperty call

### DIFF
--- a/src/charDecorator/decorators/effects.js
+++ b/src/charDecorator/decorators/effects.js
@@ -1,6 +1,6 @@
 function deepFindAll(obj, except, key, cb) {
   for (const k in obj) {
-    if (obj.hasOwnProperty(k)) {
+    if (Object.prototype.hasOwnProperty.call(obj, k)) {
       const el = obj[k];
       if (k == key) {
         cb(el);


### PR DESCRIPTION
This is in accordance with the [no-prototype-builtins](https://eslint.org/docs/rules/no-prototype-builtins) eslint rule.