### PR TITLE
Revert d632745

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5131,9 +5131,9 @@
       }
     },
     "core-js": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
-      "integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "bootstrap": "^4.3.1",
     "bootstrap-vue": "^2.0.0-rc.28",
-    "core-js": "^3.2.1",
+    "core-js": "^2.6.5",
     "electron-config": "^2.0.0",
     "electron-window-state": "^5.0.3",
     "js-yaml-loader": "^1.2.2",


### PR DESCRIPTION
Updating core-js to 3.x causes build failures. This is an issue with Babel trying to use the 2.x api and not finding it.