### PR TITLE
Trim down the Mergify config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,46 +1,9 @@
 pull_request_rules:
   # Automatic Merging (humans)
-  - name: "Automatic merge for master when tagged and CI passes (LGTM: neutral)"
+  - name: "Automatic merge for my changes to master when tagged"
     conditions:
       # Tagged ready
       - label=ready-to-merge
-
-      # CI test success
-      - status-success=unit-tests (10.x)
-      - status-success=unit-tests (12.x)
-      # Security check
-      - status-success=DeepScan
-      - status-success=security/snyk - package.json (thislooksfun)
-      - "status-neutral=LGTM analysis: JavaScript"
-      # Coverage check
-      - status-success=codecov/patch
-      - status-success=codecov/project
-      # Not WIP
-      - status-success=WIP
-      # On master branch
-      - base=master
-    actions:
-      merge:
-        method: merge
-        strict: true
-  # This rule is (hopefully) temporary, pending Mergifyio/mergify-engine#501
-  - name: "Automatic merge for master when tagged and CI passes (LGTM: success)"
-    conditions:
-      # Tagged ready
-      - label=ready-to-merge
-
-      # CI test success
-      - status-success=unit-tests (10.x)
-      - status-success=unit-tests (12.x)
-      # Security check
-      - status-success=DeepScan
-      - status-success=security/snyk - package.json (thislooksfun)
-      - "status-success=LGTM analysis: JavaScript"
-      # Coverage check
-      - status-success=codecov/patch
-      - status-success=codecov/project
-      # Not WIP
-      - status-success=WIP
       # On master branch
       - base=master
     actions:
@@ -48,50 +11,13 @@ pull_request_rules:
         method: merge
         strict: true
 
+  # This is awaiting #71
   # # Automatic Merging (bots)
-  # - name: "Automatic merge for Greenkeeper pull requests (LGTM: neutral)"
+  # - name: "Automatic merge for Greenkeeper pull requests"
   #   conditions:
   #     # Was sent from Greenkeeper
   #     - author=greenkeeper[bot]
   #     - status-success=greenkeeper/verify
-
-  #     # CI test success
-  #     - status-success=unit-tests (10.x)
-  #     - status-success=unit-tests (12.x)
-  #     # Security check
-  #     - status-success=DeepScan
-  #     - status-success=security/snyk - package.json (thislooksfun)
-  #     - "status-neutral=LGTM analysis: JavaScript"
-  #     # Coverage check
-  #     - status-success=codecov/patch
-  #     - status-success=codecov/project
-  #     # Not WIP
-  #     - status-success=WIP
-  #     # On master branch
-  #     - base=master
-  #   actions:
-  #     merge:
-  #       method: merge
-  #       strict: true
-  # # This rule is (hopefully) temporary, pending Mergifyio/mergify-engine#501
-  # - name: "Automatic merge for Greenkeeper pull requests (LGTM: success)"
-  #   conditions:
-  #     # Was sent from Greenkeeper
-  #     - author=greenkeeper[bot]
-  #     - status-success=greenkeeper/verify
-
-  #     # CI test success
-  #     - status-success=unit-tests (10.x)
-  #     - status-success=unit-tests (12.x)
-  #     # Security check
-  #     - status-success=DeepScan
-  #     - status-success=security/snyk - package.json (thislooksfun)
-  #     - "status-success=LGTM analysis: JavaScript"
-  #     # Coverage check
-  #     - status-success=codecov/patch
-  #     - status-success=codecov/project
-  #     # Not WIP
-  #     - status-success=WIP
   #     # On master branch
   #     - base=master
   #   actions:


### PR DESCRIPTION
Mergify now respects GitHub's protected branches, specifically it will wait for any required checks to complete before merging, thus explicitly stating those requried checks in .mergify.yml is no longer required.

Closes #86.