### PR TITLE
Fix 'decorators' label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -21,7 +21,7 @@ src: src/**/*
 # Assets
 assets: src/assets/**/*
 # Decorators
-decorators: src/assets/**/*
+decorators: src/charDecorator/**/*
 # Any component(s)
 components: src/components/**/*
 # Play mode


### PR DESCRIPTION
The 'decorators' label was being incorrectly applied before. This remedies that.